### PR TITLE
Update to x86_64 0.7.3 and bitflags 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ repository = "https://github.com/rust-osdev/uart_16550"
 edition = "2018"
 
 [dependencies]
-bitflags = "1.0.4"
-x86_64 = "0.5.4"
+bitflags = "1.1.0"
+x86_64 = "0.7.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ impl SerialPort {
         }
     }
 
-    fn line_sts(&self) -> LineStsFlags {
+    fn line_sts(&mut self) -> LineStsFlags {
         unsafe { LineStsFlags::from_bits_truncate(self.line_sts.read()) }
     }
 


### PR DESCRIPTION
The only code change is that the internal `line_sts` function takes `&mut self` instead of `&self` now. This is required since the newest `x86_64` requires a `&mut` reference for reading from an I/O port (since it is an operation with side effects).