### PR TITLE
enable usage with non-nightly rust

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,14 @@ jobs:
     - name: "Run cargo test"
       run: cargo test
     
+    - name: "Run cargo build for stable"
+      run: cargo build --no-default-features --features stable
+      if: runner.os != 'Windows'
+
+    - name: "Run cargo test for stable"
+      run: cargo test --no-default-features --features stable
+      if: runner.os != 'Windows'
+
     - name: "Run cargo doc"
       run: cargo doc
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,9 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1.1.0"
-x86_64 = "0.9"
+x86_64 = { version = "0.9.3", default-features = false }
+
+[features]
+default = [ "nightly" ]
+stable = [ "x86_64/stable" ]
+nightly = [ "x86_64/nightly" ]

--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ serial_port.send(42);
 ## License
 
 Licensed under the MIT license ([LICENSE](LICENSE) or <http://opensource.org/licenses/MIT>).
+
+## Crate Feature Flags
+
+* `nightly`: This is the default.
+* `stable`: Use this to build with non-nightly rust. Needs `default-features = false`.
+
+## Building with stable rust
+
+This needs to have the [compile-time requirements](https://github.com/alexcrichton/cc-rs#compile-time-requirements) of the `cc` crate installed on your system.
+It was currently only tested on Linux and MacOS.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,24 @@ impl SerialPort {
     ///
     /// This function is unsafe because the caller must ensure that the given base address
     /// really points to a serial port device.
+    #[cfg(feature = "nightly")]
     pub const unsafe fn new(base: u16) -> SerialPort {
+        SerialPort {
+            data: Port::new(base),
+            int_en: Port::new(base + 1),
+            fifo_ctrl: Port::new(base + 2),
+            line_ctrl: Port::new(base + 3),
+            modem_ctrl: Port::new(base + 4),
+            line_sts: Port::new(base + 5),
+        }
+    }
+
+    /// Creates a new serial port interface on the given I/O port.
+    ///
+    /// This function is unsafe because the caller must ensure that the given base address
+    /// really points to a serial port device.
+    #[cfg(not(feature = "nightly"))]
+    pub unsafe fn new(base: u16) -> SerialPort {
         SerialPort {
             data: Port::new(base),
             int_en: Port::new(base + 1),


### PR DESCRIPTION
default is "nightly"

to compile with stable rust:
uart_16550 = { version = "0.2.4", default-features = false, features = [ "stable" ] }