### PR TITLE
Fix default feature breakage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ bitflags = "1.1.0"
 x86_64 = { version = "0.12.2", default-features = false, features = ["instructions"] }
 
 [features]
-default = [ "x86_64/default" ]
+default = [ "nightly" ]
 stable = [ "x86_64/external_asm" ]
 nightly = [ "x86_64/nightly" ]
 


### PR DESCRIPTION
A recent change (https://github.com/rust-osdev/uart_16550/commit/1d3a8af532c82cf0a560d84851db59f14918956f) made it so some previous code using `SerialPort::new()` wouldn't compile if the user was using the default feature set.

Fixing this to just be `default = [ "nightly" ]` sets the same features for `x86_64`, while preventing breakage.

See: https://github.com/cloud-hypervisor/rust-hypervisor-firmware/pull/66

Signed-off-by: Joe Richey <joerichey@google.com>