### PR TITLE
SerialPort::new() no longer requires nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 
 use bitflags::bitflags;
 use core::fmt;
-use x86_64::instructions::port::Port;
+use x86_64::instructions::port::{Port, PortReadOnly, PortWriteOnly};
 
 macro_rules! wait_for {
     ($cond:expr) => {
@@ -56,11 +56,11 @@ bitflags! {
 /// An interface to a serial port that allows sending out individual bytes.
 pub struct SerialPort {
     data: Port<u8>,
-    int_en: Port<u8>,
-    fifo_ctrl: Port<u8>,
-    line_ctrl: Port<u8>,
-    modem_ctrl: Port<u8>,
-    line_sts: Port<u8>,
+    int_en: PortWriteOnly<u8>,
+    fifo_ctrl: PortWriteOnly<u8>,
+    line_ctrl: PortWriteOnly<u8>,
+    modem_ctrl: PortWriteOnly<u8>,
+    line_sts: PortReadOnly<u8>,
 }
 
 impl SerialPort {
@@ -68,31 +68,14 @@ impl SerialPort {
     ///
     /// This function is unsafe because the caller must ensure that the given base address
     /// really points to a serial port device.
-    #[cfg(feature = "nightly")]
     pub const unsafe fn new(base: u16) -> SerialPort {
         SerialPort {
             data: Port::new(base),
-            int_en: Port::new(base + 1),
-            fifo_ctrl: Port::new(base + 2),
-            line_ctrl: Port::new(base + 3),
-            modem_ctrl: Port::new(base + 4),
-            line_sts: Port::new(base + 5),
-        }
-    }
-
-    /// Creates a new serial port interface on the given I/O port.
-    ///
-    /// This function is unsafe because the caller must ensure that the given base address
-    /// really points to a serial port device.
-    #[cfg(not(feature = "nightly"))]
-    pub unsafe fn new(base: u16) -> SerialPort {
-        SerialPort {
-            data: Port::new(base),
-            int_en: Port::new(base + 1),
-            fifo_ctrl: Port::new(base + 2),
-            line_ctrl: Port::new(base + 3),
-            modem_ctrl: Port::new(base + 4),
-            line_sts: Port::new(base + 5),
+            int_en: PortWriteOnly::new(base + 1),
+            fifo_ctrl: PortWriteOnly::new(base + 2),
+            line_ctrl: PortWriteOnly::new(base + 3),
+            modem_ctrl: PortWriteOnly::new(base + 4),
+            line_sts: PortReadOnly::new(base + 5),
         }
     }
 


### PR DESCRIPTION
Also, use the `PortWriteOnly` and `PortReadOnly` aliases when appropritae.

Signed-off-by: Joe Richey <joerichey@google.com>