### PR TITLE
Added send_raw() function to allow sending arbitrary binary data using the serial port.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,9 @@ name: Build
 
 on:
   push:
-    branches:
-      - 'master'
-    tags:
-      - '*'
+  pull_request:
   schedule:
     - cron: '40 4 * * *'   # every day at 4:40
-  pull_request:
 
 jobs:
   test:

--- a/src/port.rs
+++ b/src/port.rs
@@ -86,6 +86,14 @@ impl SerialPort {
         }
     }
 
+    /// Sends a raw byte on the serial port, intended for binary data.
+    pub fn send_raw(&mut self, data: u8) {
+        unsafe {
+            wait_for!(self.line_sts().contains(LineStsFlags::OUTPUT_EMPTY));
+            self.data.write(data);
+        }
+    }
+
     /// Receives a byte on the serial port.
     pub fn receive(&mut self) -> u8 {
         unsafe {


### PR DESCRIPTION
See discussion here: https://github.com/rust-osdev/uart_16550/issues/19

The `send()` function has a special case for 0x08 and 0x7F in order to allow terminals to correctly display ASCII backspace and delete characters. However, inserting the additional 0x08 0x20 bytes can mangle binary data being sent using the serial port. Thus, this PR adds a new `send_raw()` function which allows sending bytes unchanged. By using a new function, this should not break backwards compatibility with previous versions of the crate.