### PR TITLE
remove unknown nightly feature 'const_ptr_offset'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@
 
 #![no_std]
 #![warn(missing_docs)]
-#![cfg_attr(feature = "nightly", feature(const_ptr_offset))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(not(any(feature = "stable", feature = "nightly")))]


### PR DESCRIPTION
This seems to let it build again.

Seems related to https://github.com/rust-lang/rust/issues/71499 and https://github.com/rust-lang/rust/pull/93957