### PR TITLE
Remove use of `stable` and `nightly` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,16 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1.1.0"
+rustversion = "1.0.5"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-x86_64 = { version = "0.14.0", default-features = false, features = ["instructions"] }
+x86_64 = { version = "0.14.9", default-features = false, features = ["instructions"] }
 
 [features]
-default = [ "nightly" ]
-stable = [ "x86_64/external_asm" ]
-nightly = [ "x86_64/inline_asm" ]
+default = []
+# TOOD: Remove these deprecated features on next breaking release
+stable = []
+nightly = []
 
 [package.metadata.release]
 dev-version = false

--- a/README.md
+++ b/README.md
@@ -47,11 +47,6 @@ serial_port.send(42);
 let data = serial_port.receive();
 ```
 
-## Crate Feature Flags
-
-* `nightly`: This is the default.
-* `stable`: Use this to build with non-nightly rust. Needs `default-features = false`.
-
 ## Building with stable rust
 
 This needs to have the [compile-time requirements](https://github.com/alexcrichton/cc-rs#compile-time-requirements) of the `cc` crate installed on your system.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,9 +62,6 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(not(any(feature = "stable", feature = "nightly")))]
-compile_error!("Either the `stable` or `nightly` feature must be enabled");
-
 use bitflags::bitflags;
 
 macro_rules! wait_for {

--- a/src/mmio.rs
+++ b/src/mmio.rs
@@ -20,20 +20,7 @@ impl MmioSerialPort {
     ///
     /// This function is unsafe because the caller must ensure that the given base address
     /// really points to a serial port device.
-    #[cfg(feature = "nightly")]
-    pub const unsafe fn new(base: usize) -> Self {
-        let base_pointer = base as *mut u8;
-        Self {
-            data: AtomicPtr::new(base_pointer),
-            int_en: AtomicPtr::new(base_pointer.add(1)),
-            fifo_ctrl: AtomicPtr::new(base_pointer.add(2)),
-            line_ctrl: AtomicPtr::new(base_pointer.add(3)),
-            modem_ctrl: AtomicPtr::new(base_pointer.add(4)),
-            line_sts: AtomicPtr::new(base_pointer.add(5)),
-        }
-    }
-
-    #[cfg(feature = "stable")]
+    #[rustversion::attr(since(1.61), const)]
     pub unsafe fn new(base: usize) -> Self {
         let base_pointer = base as *mut u8;
         Self {


### PR DESCRIPTION
We can now use `rustversion` to mark `MmioSerialPort::new()` as const or
not depending on the rust version. The features can't be removed yet as
that would be a breaking change.

This removes code duplication and lets us avoid increasing our MSRV. We also no longer need any nightly features for `x86_64` with the release of `0.14.9`.

Fixes #23

Signed-off-by: Joe Richey <joerichey@google.com>