### PR TITLE
serial also on arch x86

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //!
 //! ```no_run
-//! # #[cfg(target_arch = "x86_64")]
+//! # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 //! # fn main() {
 //! use uart_16550::SerialPort;
 //!
@@ -33,7 +33,7 @@
 //! // To receive a byte:
 //! let data = serial_port.receive();
 //! # }
-//! # #[cfg(not(target_arch = "x86_64"))]
+//! # #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 //! # fn main() {}
 //! ```
 //!
@@ -74,12 +74,12 @@ macro_rules! wait_for {
 
 /// Memory mapped implementation
 mod mmio;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 /// Port asm commands implementation
 mod port;
 
 pub use crate::mmio::MmioSerialPort;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub use crate::port::SerialPort;
 
 bitflags! {

--- a/src/port.rs
+++ b/src/port.rs
@@ -5,7 +5,7 @@ use x86_64::instructions::port::{Port, PortReadOnly, PortWriteOnly};
 use crate::LineStsFlags;
 
 /// A port-mapped UART.
-#[cfg_attr(docsrs, doc(cfg(target_arch = "x86_64")))]
+#[cfg_attr(docsrs, doc(cfg(any(target_arch = "x86", target_arch = "x86_64"))))]
 pub struct SerialPort {
     data: Port<u8>,
     int_en: PortWriteOnly<u8>,


### PR DESCRIPTION
Hi. Unfortunately, this crate is not usable when compiling for x86 (without _64).