### PR TITLE
Update port.rs to do \r\n

### DIFF
--- a/src/port.rs
+++ b/src/port.rs
@@ -100,6 +100,8 @@ impl SerialPort {
     }
 
     /// Sends a byte on the serial port.
+    /// 0x08 (backspace) and 0x7F (delete) get replaced with 0x08, 0x20, 0x08 and 0x0A (\n) gets replaced with \r\n.
+    /// If this replacement is unwanted use [SerialPort::send_raw] instead.
     pub fn send(&mut self, data: u8) {
         match data {
             8 | 0x7F => {
@@ -107,9 +109,9 @@ impl SerialPort {
                 self.send_raw(b' ');
                 self.send_raw(8);
             }
-            0x0a => {
-                self.send_raw(0x0d);
-                self.send_raw(0x0a);
+            0x0A => {
+                self.send_raw(0x0D);
+                self.send_raw(0x0A);
             }
             data => {
                 self.send_raw(data);

--- a/src/port.rs
+++ b/src/port.rs
@@ -107,6 +107,10 @@ impl SerialPort {
                 self.send_raw(b' ');
                 self.send_raw(8);
             }
+            0x0a => {
+                self.send_raw(0x0d);
+                self.send_raw(0x0a);
+            }
             data => {
                 self.send_raw(data);
             }


### PR DESCRIPTION
rust uses only \n regardless of platform and some serial monitors such as the qemu one need \r\n. This would fix this.