### PR TITLE
docs.rs: set targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,12 @@ embedded-io = ["dep:embedded-io"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+default-garget = [ "x86_64-unknown-none" ]
+# Builds on any no_std target. This selection shows that the crate works on x86,
+# ARM, and RISC-V as example (most popular platforms).
+targets = [
+  "aarch64-unknown-none",
+  "i686-unknown-uefi",
+  "riscv64im-unknown-none-elf",
+  "x86_64-unknown-none",
+]

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -38,7 +38,7 @@ checksum = "8bb0fd6580eeed0103c054e3fba2c2618ff476943762f28a645b63b8692b21c9"
 
 [[package]]
 name = "uart_16550"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags",
 ]


### PR DESCRIPTION
Make sure we build the docs for a variety of targets. Technically, the
doc is the same for every target; this way - however - we can better
indicate that this crate is indeed compatible with every platform.

https://blog.rust-lang.org/2026/04/04/docsrs-only-default-targets/