### PR TITLE
lib: change signature of Uart16550::config() to be more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- **Breaking:** Changed the return type of `Uart16550::config(&self)` from
+  `(&Config, &B::Address)` to `(&Config, &B)`
+
 ## 0.6.0 - 2026-03-28
 
 - Rename `Uart16550::try_send_bytes()` to `Uart16550::send_bytes()`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,6 @@ mod tty;
 #[derive(Debug)]
 pub struct Uart16550<B: Backend> {
     backend: B,
-    base_address: B::Address,
     // The currently active config.
     config: Config,
 }
@@ -325,7 +324,6 @@ impl Uart16550<PioBackend> {
 
         Ok(Self {
             backend,
-            base_address,
             // Will be replaced by the actual config in init() afterwards.
             config: Config::default(),
         })
@@ -375,7 +373,6 @@ impl Uart16550<MmioBackend> {
 
         Ok(Self {
             backend,
-            base_address,
             // Will be replaced by the actual config in init() afterwards.
             config: Config::default(),
         })
@@ -911,12 +908,13 @@ impl<B: Backend> Uart16550<B> {
     /* ----- Misc ----------------------------------------------------------- */
 
     /// Returns the config from the last call to [`Self::init`] together with
-    /// the base address of the underlying hardware.
+    /// the corresponding [`Backend`].
     ///
+    /// Via the backend, you can get the base address using [`Backend::base()`].
     /// To get the values that are currently in the registers, consider using
     /// [`Self::config_register_dump`].
-    pub const fn config(&self) -> (&Config, B::Address) {
-        (&self.config, self.base_address)
+    pub const fn config(&self) -> (&Config, &B) {
+        (&self.config, &self.backend)
     }
 
     /// Queries the device and returns a [`ConfigRegisterDump`].

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -32,13 +32,13 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "qemu-exit"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb0fd6580eeed0103c054e3fba2c2618ff476943762f28a645b63b8692b21c9"
+checksum = "8189cbf0422ac15d7d544ed5f331fbe4e5b9da88133568fd359083b186a547f3"
 
 [[package]]
 name = "uart_16550"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags",
 ]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -13,4 +13,4 @@ opt-level = "s"
 anyhow = { version = "1.0", default-features = false }
 log = { version = "0.4", default-features = false }
 uart_16550 = { path = "../." }
-qemu-exit = {  version = "3.0.2", default-features = false }
+qemu-exit = {  version = "4.0.0", default-features = false }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -38,7 +38,8 @@ extern "C" fn rust_entry() -> ! {
 fn exit_qemu(success: bool) -> ! {
     // configured in Makefile
     let port = 0xf4;
-    let exit = qemu_exit::X86::new(port, 73);
+    // SAFETY: we have exclusive access and the port is valid
+    let exit = unsafe { qemu_exit::X86::new(port, 73) };
     if success {
         exit.exit_success()
     } else {


### PR DESCRIPTION
Further, this removes the need to store the same data twice.