### PR TITLE
Allow configuring whether to care about the CTS line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - **Breaking:** Changed the return type of `Uart16550::config(&self)` from
   `(&Config, &B::Address)` to `(&Config, &B)`
+- **Breaking:** `ready_to_send()` (and `send_bytes()` in turn) doesn't check
+  `MSR::CTS` anymore by default, as modern hardware tends to leave that pin
+  disconnected. This behavior is configurable through `Config::flow_control`.
+  Additionally, for manual checks, users can check
+  `if device.msr().contains(MSR::CTS) {}`.
 
 ## 0.6.0 - 2026-03-28
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,6 +151,12 @@ pub struct Config {
     pub extra_stop_bits: bool,
     /// Whether parity bits should be used.
     pub parity: Parity,
+    /// Whether to wait for CTS before sending.
+    ///
+    /// Only activate this if your hardware connects the CTS/RTS flow control
+    /// signals and you wish to make use of them. Keep this setting disabled to
+    /// make sure that the UART works when CTS is left disconnected.
+    pub flow_control: bool,
 }
 
 impl Config {
@@ -176,6 +182,7 @@ impl Config {
         data_bits: WordLength::EightBits,
         extra_stop_bits: false,
         parity: Parity::Disabled,
+        flow_control: false,
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -668,8 +668,6 @@ impl<B: Backend> Uart16550<B> {
     /// an established connection.
     pub fn ready_to_send(&mut self) -> Result<(), ByteSendError> {
         let lsr = self.lsr();
-        let msr = self.msr();
-        let mcr = self.mcr();
 
         // In FIFO mode, this bit is set when the transmitter’s FIFO is
         // completely empty, being 0 if there is at least one byte in the
@@ -681,8 +679,16 @@ impl<B: Backend> Uart16550<B> {
 
         // Software flow control. TODO, what to do with hardware flow control?
         // Is this something we can and should support?
-        if !mcr.contains(MCR::LOOP_BACK) && !msr.contains(MSR::CTS) {
-            return Err(ByteSendError::RemoteNotClearToSend);
+        if self.config.flow_control {
+            // The CTS line is meaningless when in loopback mode.
+            let mcr = self.mcr();
+            if !mcr.contains(MCR::LOOP_BACK) {
+                let msr = self.msr();
+
+                if !msr.contains(MSR::CTS) {
+                    return Err(ByteSendError::RemoteNotClearToSend);
+                }
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Resolves #65.

I have chosen to make "ignore CTS" the default, as that is the choice that is more likely to simply work for the user, as the aforementioned issue demonstrates.

Since the PR adds a new field to the `Config` struct, it would probably need to be a semver bump. Perhaps that's a good opportunity to mark the `Config` struct as `#[non_exhaustive]`, but I'll leave that call up to you.